### PR TITLE
Default to name fix

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -57,7 +57,7 @@ module.exports = {
             ...rest
           } = options;
 
-          if (!to) reject(new Error("'to' field is required."));
+          if (!to && !settings.defaultTo) reject(new Error("Either 'to' or `defaultTo` field is required."));
 
           const msg = {
             Messages: [

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,33 +1,38 @@
-'use strict';
+"use strict";
 
 /* eslint-disable import/no-unresolved */
-const mailjet = require('node-mailjet');
-const { removeUndefined } = require('strapi-utils');
+const mailjet = require("node-mailjet");
+const { removeUndefined } = require("strapi-utils");
 
-function normalizeReceiver(receiver, receiverName, defaultReceiver, defaultReceiverName) {
+function normalizeReceiver(
+  receiver,
+  receiverName,
+  defaultReceiver,
+  defaultReceiverName
+) {
   // Receiver not given
-  if (typeof receiver === 'undefined') {
-    return [{Email: defaultReceiver, Name: defaultReceiverName}];
+  if (typeof receiver === "undefined") {
+    return [{ Email: defaultReceiver, Name: defaultReceiverName }];
   }
 
   // Receiver given as string
-  if (typeof receiver === 'string') {
-    const receiverObj = {Email: receiver};
+  if (typeof receiver === "string") {
+    const receiverObj = { Email: receiver };
     // If receiver email given we don't use the default receiver name
     if (receiverName) {
-      receiverObj['Name'] = receiverName;
+      receiverObj["Name"] = receiverName;
     }
     return [receiverObj];
   }
 
   // Array of receivers
   if (Array.isArray(receiver)) {
-    return to.map(receiverEntry => {
-      if (typeof receiverEntry === 'string') {
-        return {Email: receiver};
+    return receiver.map((receiverEntry) => {
+      if (typeof receiverEntry === "string") {
+        return { Email: receiverEntry };
       }
       return receiverEntry;
-    }));
+    });
   }
 }
 
@@ -35,10 +40,10 @@ module.exports = {
   init: (providerOptions = {}, settings = {}) => {
     const mailjetClient = mailjet.connect(
       providerOptions.publicApiKey,
-      providerOptions.secretApiKey,
+      providerOptions.secretApiKey
     );
     return {
-      send: options => {
+      send: (options) => {
         return new Promise((resolve, reject) => {
           const {
             from,
@@ -57,7 +62,8 @@ module.exports = {
             ...rest
           } = options;
 
-          if (!to && !settings.defaultTo) reject(new Error("Either 'to' or `defaultTo` field is required."));
+          if (!to && !settings.defaultTo)
+            reject(new Error("Either 'to' or `defaultTo` field is required."));
 
           const msg = {
             Messages: [
@@ -66,7 +72,12 @@ module.exports = {
                   Email: from || settings.defaultFrom,
                   Name: fromName || settings.defaultFromName,
                 },
-                To: normalizeReceiver(to, toName, settings.defaultTo, settings.defaultToName),
+                To: normalizeReceiver(
+                  to,
+                  toName,
+                  settings.defaultTo,
+                  settings.defaultToName
+                ),
                 Subject: subject,
                 TextPart: text,
                 HTMLPart: html,
@@ -75,138 +86,148 @@ module.exports = {
             ],
           };
           if (cc || settings.defaultCc) {
-            msg.Cc = normalizeReceiver(cc, ccName, settings.defaultCc, settings.defaultCcName);
+            msg.Cc = normalizeReceiver(
+              cc,
+              ccName,
+              settings.defaultCc,
+              settings.defaultCcName
+            );
           }
           if (bcc || settings.defaultBcc) {
-            msg.Bcc = normalizeReceiver(bcc, bccName, settings.defaultBcc, settings.defaultBccName);
+            msg.Bcc = normalizeReceiver(
+              bcc,
+              bccName,
+              settings.defaultBcc,
+              settings.defaultBccName
+            );
           }
           if (attachments) msg.Attachments = attachments;
 
           mailjetClient
-            .post('send', { version: 'v3.1' })
+            .post("send", { version: "v3.1" })
             .request(removeUndefined(msg))
             .then(resolve)
-            .catch(error => reject(error));
+            .catch((error) => reject(error));
         });
       },
-      addContactToList: options => {
+      addContactToList: (options) => {
         return new Promise((resolve, reject) => {
           const request = mailjetClient
-            .post('contact')
+            .post("contact")
             .id(options.id)
-            .action('managecontactslists')
+            .action("managecontactslists")
             .request({
               ContactsLists: [
                 {
                   ListID: options.listId,
-                  Action: 'addforce',
+                  Action: "addforce",
                 },
               ],
             });
 
           request
-            .then(result => resolve(result.body))
-            .catch(err => reject(err.message));
+            .then((result) => resolve(result.body))
+            .catch((err) => reject(err.message));
         });
       },
-      createContact: options => {
+      createContact: (options) => {
         return new Promise((resolve, reject) => {
           const request = mailjetClient
-            .post('contact', { version: 'v3' })
+            .post("contact", { version: "v3" })
             .request({
-              IsExcludedFromCampaigns: options.excludeFromCampaigns || 'true',
+              IsExcludedFromCampaigns: options.excludeFromCampaigns || "true",
               Name: options.name,
               Email: options.email,
             });
 
           request
-            .then(result => resolve(result.body))
-            .catch(err => reject(err.message));
+            .then((result) => resolve(result.body))
+            .catch((err) => reject(err.message));
         });
       },
-      createContactList: options => {
+      createContactList: (options) => {
         return new Promise((resolve, reject) => {
           const request = mailjetClient
-            .post('contactslist', { version: 'v3' })
+            .post("contactslist", { version: "v3" })
             .request({
               Name: options.name,
             });
 
           request
-            .then(result => resolve(result.body))
-            .catch(err => reject(err.message));
+            .then((result) => resolve(result.body))
+            .catch((err) => reject(err.message));
         });
       },
-      removeContactFromList: options => {
+      removeContactFromList: (options) => {
         return new Promise((resolve, reject) => {
           const request = mailjetClient
-            .post('contact')
+            .post("contact")
             .id(options.id)
-            .action('managecontactslists')
+            .action("managecontactslists")
             .request({
               ContactsLists: [
                 {
                   ListID: options.listId,
-                  Action: 'remove',
+                  Action: "remove",
                 },
               ],
             });
 
           request
-            .then(result => resolve(result.body))
-            .catch(err => reject(err.message));
+            .then((result) => resolve(result.body))
+            .catch((err) => reject(err.message));
         });
       },
-      retrieveContact: options => {
+      retrieveContact: (options) => {
         return new Promise((resolve, reject) => {
           const request = mailjetClient
-            .get('contact', { version: 'v3' })
+            .get("contact", { version: "v3" })
             .id(options.contactId)
             .request();
 
           request
-            .then(result => resolve(result.body))
-            .catch(err => reject(err.message));
+            .then((result) => resolve(result.body))
+            .catch((err) => reject(err.message));
         });
       },
-      subscribeContactToList: options => {
+      subscribeContactToList: (options) => {
         return new Promise((resolve, reject) => {
           const request = mailjetClient
-            .post('contact')
+            .post("contact")
             .id(options.id)
-            .action('managecontactslists')
+            .action("managecontactslists")
             .request({
               ContactsLists: [
                 {
                   ListID: options.listId,
-                  Action: 'addforce',
+                  Action: "addforce",
                 },
               ],
             });
 
           request
-            .then(result => resolve(result.body))
-            .catch(err => reject(err.message));
+            .then((result) => resolve(result.body))
+            .catch((err) => reject(err.message));
         });
       },
-      unsubscribeContactFromList: options => {
+      unsubscribeContactFromList: (options) => {
         return new Promise((resolve, reject) => {
           const request = mailjetClient
-            .post('contact')
+            .post("contact")
             .id(options.id)
-            .action('managecontactslists')
+            .action("managecontactslists")
             .request({
               ContactsLists: [
                 {
                   ListID: options.listId,
-                  Action: 'unsub',
+                  Action: "unsub",
                 },
               ],
             });
 
           request
-            .then(result => resolve(result.body))
-            .catch(err => reject(err.message));
+            .then((result) => resolve(result.body))
+            .catch((err) => reject(err.message));
         });
       },
     };

--- a/lib/index.js
+++ b/lib/index.js
@@ -66,7 +66,7 @@ module.exports = {
                   Email: from || settings.defaultFrom,
                   Name: fromName || settings.defaultFromName,
                 },
-                to: normalizeReceiver(to, toName, settings.defaultTo, settings.defaultToName),
+                To: normalizeReceiver(to, toName, settings.defaultTo, settings.defaultToName),
                 Subject: subject,
                 TextPart: text,
                 HTMLPart: html,

--- a/lib/index.js
+++ b/lib/index.js
@@ -66,24 +66,20 @@ module.exports = {
             reject(new Error("Either 'to' or `defaultTo` field is required."));
 
           const msg = {
-            Messages: [
-              {
-                From: {
-                  Email: from || settings.defaultFrom,
-                  Name: fromName || settings.defaultFromName,
-                },
-                To: normalizeReceiver(
-                  to,
-                  toName,
-                  settings.defaultTo,
-                  settings.defaultToName
-                ),
-                Subject: subject,
-                TextPart: text,
-                HTMLPart: html,
-                ...rest,
-              },
-            ],
+            From: {
+              Email: from || settings.defaultFrom,
+              Name: fromName || settings.defaultFromName,
+            },
+            To: normalizeReceiver(
+              to,
+              toName,
+              settings.defaultTo,
+              settings.defaultToName
+            ),
+            Subject: subject,
+            TextPart: text,
+            HTMLPart: html,
+            ...rest,
           };
           if (cc || settings.defaultCc) {
             msg.Cc = normalizeReceiver(
@@ -105,7 +101,7 @@ module.exports = {
 
           mailjetClient
             .post("send", { version: "v3.1" })
-            .request(removeUndefined(msg))
+            .request(removeUndefined({ Messages: [msg] }))
             .then(resolve)
             .catch((error) => reject(error));
         });

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,33 @@
 const mailjet = require('node-mailjet');
 const { removeUndefined } = require('strapi-utils');
 
+function normalizeReceiver(receiver, receiverName, defaultReceiver, defaultReceiverName) {
+  // Receiver not given
+  if (typeof receiver === 'undefined') {
+    return [{Email: defaultReceiver, Name: defaultReceiverName}];
+  }
+
+  // Receiver given as string
+  if (typeof receiver === 'string') {
+    const receiverObj = {Email: receiver};
+    // If receiver email given we don't use the default receiver name
+    if (receiverName) {
+      receiverObj['Name'] = receiverName;
+    }
+    return [receiverObj];
+  }
+
+  // Array of receivers
+  if (Array.isArray(receiver)) {
+    return to.map(receiverEntry => {
+      if (typeof receiverEntry === 'string') {
+        return {Email: receiver};
+      }
+      return receiverEntry;
+    }));
+  }
+}
+
 module.exports = {
   init: (providerOptions = {}, settings = {}) => {
     const mailjetClient = mailjet.connect(
@@ -32,22 +59,6 @@ module.exports = {
 
           if (!to) reject(new Error("'to' field is required."));
 
-          let To;
-          if (typeof to === 'string' || to instanceof String) {
-            To = [{ Email: to, Name: toName || settings.defaultToName }];
-          } else if (Array.isArray(to)) {
-            To = to.map(toEntry => ({
-              Email: toEntry.email || settings.defaultTo,
-              Name: toEntry.toName || settings.defaultToName,
-            }));
-          } else {
-            reject(
-              new Error(
-                "'to' must be either a String or an Array of objects. Read more: https://github.com/ijsto/strapi-provider-email-mailjet#configuration",
-              ),
-            );
-          }
-
           const msg = {
             Messages: [
               {
@@ -55,7 +66,7 @@ module.exports = {
                   Email: from || settings.defaultFrom,
                   Name: fromName || settings.defaultFromName,
                 },
-                To,
+                to: normalizeReceiver(to, toName, settings.defaultTo, settings.defaultToName),
                 Subject: subject,
                 TextPart: text,
                 HTMLPart: html,
@@ -64,20 +75,10 @@ module.exports = {
             ],
           };
           if (cc || settings.defaultCc) {
-            msg.Cc = [
-              {
-                Email: cc || settings.defaultCc,
-                Name: ccName || settings.defaultCcName,
-              },
-            ];
+            msg.Cc = normalizeReceiver(cc, ccName, settings.defaultCc, settings.defaultCcName);
           }
           if (bcc || settings.defaultBcc) {
-            msg.Bcc = [
-              {
-                Email: bcc || settings.defaultBcc,
-                Name: bccName || settings.defaultBccName,
-              },
-            ];
+            msg.Bcc = normalizeReceiver(bcc, bccName, settings.defaultBcc, settings.defaultBccName);
           }
           if (attachments) msg.Attachments = attachments;
 


### PR DESCRIPTION
Fixes problem of potential mismatch of receiver's email address and name as described [here](https://github.com/ijsto/strapi-provider-email-mailjet/pull/3#issuecomment-731742512).
Also adds support of email only arrays (`['email1@..., email2@...]`) and enables throwing 'empty to' error only if both `to` and `defaultTo` are not set.