### PR TITLE
remove deprecated function removeUndefined

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,6 @@
 
 /* eslint-disable import/no-unresolved */
 const mailjet = require('node-mailjet');
-const { removeUndefined } = require('@strapi/utils');
 
 function normalizeReceiver(
   receiver,
@@ -103,7 +102,7 @@ module.exports = {
 
           mailjetClient
             .post('send', { version: 'v3.1' })
-            .request(removeUndefined({ Messages: [msg] }))
+            .request({ Messages: [msg] })
             .then(resolve)
             .catch(error => reject(error));
         });


### PR DESCRIPTION
Utils function not part of Strapi 5 anymore: https://docs.strapi.io/dev-docs/migration/v4-to-v5/breaking-changes/strapi-utils-refactored